### PR TITLE
Allow the user to pass a custom path to a repository

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,6 +2,7 @@
 name = "semantic-rs"
 version = "0.1.0"
 dependencies = [
+ "argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "commit_analyzer 0.1.0 (git+https://github.com/semantic-rs/commit-analyzer)",
  "commit_walker 0.1.0 (git+https://github.com/semantic-rs/commit-walker)",
  "regex 0.1.44 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -26,6 +27,11 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
+
+[[package]]
+name = "argparse"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,3 +12,4 @@ regex = "0.1"
 semver = "0.2.1"
 commit_walker = { git = "https://github.com/semantic-rs/commit-walker" }
 commit_analyzer = { git = "https://github.com/semantic-rs/commit-analyzer" }
+argparse = "0.2.1"


### PR DESCRIPTION
PR for #6
This PR allows users to specify a custom repository path. If that parameter is omitted it defaults to the current directory.

With custom path:
```bash
$ semantic-rs -p /home/foo/bar
```

Current directory:
```bash
$ semantic-rs 
```