### PR TITLE
refactor: Use borrowed str everywhere

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -2,11 +2,11 @@ use std::error::Error;
 use git2_commit;
 use time;
 
-pub fn generate_commit_message(new_version: String) -> String {
+pub fn generate_commit_message(new_version: &str) -> String {
     format!("Bump version to {}", new_version).into()
 }
 
-pub fn commit_files(repository_path: &String, new_version: String) -> Result<(), String> {
+pub fn commit_files(repository_path: &str, new_version: &str) -> Result<(), String> {
     let files = vec!["Cargo.toml"];
     match git2_commit::add(&repository_path, &files[..]) {
         Ok(_) => {},

--- a/src/main.rs
+++ b/src/main.rs
@@ -74,15 +74,15 @@ fn main() {
     logger::stdout(format!("Commits analyzed. Bump will be {:?}", bump));
 
     let new_version = match version_bump(&version, bump) {
-        Some(new_version) => new_version,
+        Some(new_version) => new_version.to_string(),
         None => {
             logger::stdout("No version bump. Nothing to do.");
             process::exit(0);
         }
     };
 
-    logger::stdout(format!("New version: {}", new_version.to_string()));
-    match toml_file::write_new_version(&repository_path, new_version.to_string()) {
+    logger::stdout(format!("New version: {}", new_version));
+    match toml_file::write_new_version(&repository_path, &new_version) {
         Ok(_)    => { },
         Err(err) => {
             logger::stderr(format!("Writing `Cargo.toml` failed: {:?}", err));
@@ -99,7 +99,7 @@ fn main() {
         }
     }
 
-    match git::commit_files(&repository_path, new_version.to_string()) {
+    match git::commit_files(&repository_path, &new_version) {
         Ok(_)    => { },
         Err(err) => {
             logger::stderr(format!("Committing `Cargo.toml` failed: {:?}", err));

--- a/src/toml_file.rs
+++ b/src/toml_file.rs
@@ -33,7 +33,7 @@ pub fn file_with_new_version(file: String, new_version: &str) -> String {
     re.replace(&file, &new_version[..])
 }
 
-pub fn read_from_file(repository_path: &String) -> Result<String, TomlError> {
+pub fn read_from_file(repository_path: &str) -> Result<String, TomlError> {
     let file_path = Path::new(&repository_path).join("Cargo.toml");
     let cargo_file = match read_cargo_toml(&file_path) {
         Ok(buffer) => buffer,
@@ -46,10 +46,10 @@ pub fn read_from_file(repository_path: &String) -> Result<String, TomlError> {
     }
 }
 
-pub fn write_new_version(repository_path: &String, new_version: String) -> Result<(), Error> {
+pub fn write_new_version(repository_path: &str, new_version: &str) -> Result<(), Error> {
     let file_path = Path::new(&repository_path).join("Cargo.toml");
     let cargo_toml = try!(read_cargo_toml(&file_path));
-    let new_cargo_toml = file_with_new_version(cargo_toml, &new_version);
+    let new_cargo_toml = file_with_new_version(cargo_toml, new_version);
     let mut handle = try!(OpenOptions::new().read(true).write(true).open(file_path));
     handle.write_all(new_cargo_toml.as_bytes())
 }


### PR DESCRIPTION
A borrowed String is an anti-pattern and we nearly never need full
ownership of the passed string.