### PR TITLE
Docopt

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,11 +2,12 @@
 name = "semantic-rs"
 version = "0.1.0"
 dependencies = [
- "argparse 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "clog 0.9.0 (git+https://github.com/semantic-rs/clog-lib?branch=public-raw-parsing)",
+ "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2-commit 0.1.0 (git+https://github.com/badboy/git2-commit-rs)",
  "regex 0.1.48 (registry+https://github.com/rust-lang/crates.io-index)",
+ "rustc-serialize 0.3.16 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.2.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "term 0.2.14 (registry+https://github.com/rust-lang/crates.io-index)",
  "toml 0.1.25 (registry+https://github.com/rust-lang/crates.io-index)",
@@ -28,11 +29,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 dependencies = [
  "memchr 0.1.7 (registry+https://github.com/rust-lang/crates.io-index)",
 ]
-
-[[package]]
-name = "argparse"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
 
 [[package]]
 name = "bitflags"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,8 @@ term = "0.2"
 toml = "0.1"
 regex = "0.1"
 semver = "0.2.1"
-argparse = "0.2.1"
+docopt = "0.6.78"
+rustc-serialize = "0.3.16"
 git2-commit = { git = "https://github.com/badboy/git2-commit-rs" }
 git2 = "0.3.4"
 clog = { git = "https://github.com/semantic-rs/clog-lib", branch = "public-raw-parsing" }

--- a/src/main.rs
+++ b/src/main.rs
@@ -15,6 +15,8 @@ extern crate clog;
 
 use docopt::Docopt;
 use commit_analyzer::CommitType;
+use std::process;
+use semver::Version;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 const USAGE: &'static str = "
@@ -49,9 +51,6 @@ fn version_bump(version: &Version, bump: CommitType) -> Option<Version> {
 
     Some(version)
 }
-
-use std::process;
-use semver::Version;
 
 fn main() {
     let args: Args = Docopt::new(USAGE)

--- a/src/main.rs
+++ b/src/main.rs
@@ -16,7 +16,7 @@ extern crate clog;
 use docopt::Docopt;
 use commit_analyzer::CommitType;
 
-
+const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 const USAGE: &'static str = "
 semantic.rs 🚀
 
@@ -35,6 +35,7 @@ Options:
 struct Args {
     flag_path: String,
     flag_dry_run: bool,
+    flag_version: bool,
 }
 
 fn version_bump(version: &Version, bump: CommitType) -> Option<Version> {
@@ -56,6 +57,11 @@ fn main() {
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| d.decode())
         .unwrap_or_else(|e| e.exit());
+
+    if args.flag_version {
+        println!("semantic.rs 🚀 -- v{}", VERSION);
+        process::exit(0);
+    }
 
     println!("semantic.rs 🚀");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,16 +3,39 @@ mod toml_file;
 mod git;
 mod changelog;
 mod commit_analyzer;
+
+extern crate rustc_serialize;
 extern crate toml;
 extern crate regex;
 extern crate semver;
-extern crate argparse;
+extern crate docopt;
 extern crate git2_commit;
 extern crate git2;
 extern crate clog;
 
-use argparse::{ArgumentParser, Store};
+use docopt::Docopt;
 use commit_analyzer::CommitType;
+
+
+const USAGE: &'static str = "
+semantic.rs 🚀
+
+Usage:
+  semantic-rs [options]
+  semantic-rs --version
+
+Options:
+  -h --help              Show this screen.
+  --version              Show version.
+  -p PATH, --path=PATH   Specifies the repository path. [default: .]
+  -n, --dry-run          Run without writing, committing, pushing or publishing anything.
+";
+
+#[derive(Debug, RustcDecodable)]
+struct Args {
+    flag_path: String,
+    flag_dry_run: bool,
+}
 
 fn version_bump(version: &Version, bump: CommitType) -> Option<Version> {
     let mut version = version.clone();
@@ -29,25 +52,17 @@ fn version_bump(version: &Version, bump: CommitType) -> Option<Version> {
 use std::process;
 use semver::Version;
 
-fn get_repository_path() -> String {
-    let mut path = ".".to_string();
-    {
-        let mut ap = ArgumentParser::new();
-        ap.refer(&mut path)
-            .add_option(&["-p", "--path"], Store,
-                        "Specifies the repository path. If ommitted it defaults to current directory");
-        ap.parse_args_or_exit();
-    }
-    path
-}
-
 fn main() {
+    let args: Args = Docopt::new(USAGE)
+        .and_then(|d| d.decode())
+        .unwrap_or_else(|e| e.exit());
+
     println!("semantic.rs 🚀");
 
     logger::stdout("Analyzing your repository");
-    let repository_path = get_repository_path();
+    let repository_path = &args.flag_path;
 
-    match git2::Repository::open(&repository_path) {
+    match git2::Repository::open(repository_path) {
         Ok(_) => { },
         Err(e) => {
             logger::stderr(format!("Could not open the git repository: {:?}", e));
@@ -55,7 +70,7 @@ fn main() {
         }
     };
 
-    let version = match toml_file::read_from_file(&repository_path) {
+    let version = match toml_file::read_from_file(repository_path) {
         Ok(toml) => toml,
         Err(e) => {
             logger::stderr(format!("Reading `Cargo.toml` failed: {:?}", e));
@@ -68,7 +83,7 @@ fn main() {
 
     logger::stdout("Analyzing commits");
 
-    let bump = git::version_bump_since_latest(&repository_path);
+    let bump = git::version_bump_since_latest(repository_path);
     logger::stdout(format!("Commits analyzed. Bump will be {:?}", bump));
 
     let new_version = match version_bump(&version, bump) {
@@ -80,7 +95,7 @@ fn main() {
     };
 
     logger::stdout(format!("New version: {}", new_version));
-    match toml_file::write_new_version(&repository_path, &new_version) {
+    match toml_file::write_new_version(repository_path, &new_version) {
         Ok(_)    => { },
         Err(err) => {
             logger::stderr(format!("Writing `Cargo.toml` failed: {:?}", err));
@@ -89,7 +104,7 @@ fn main() {
     }
 
     logger::stdout(format!("Writing Changelog"));
-    match changelog::write(&repository_path, &version.to_string(), &new_version.to_string()) {
+    match changelog::write(repository_path, &version.to_string(), &new_version.to_string()) {
         Ok(_)    => { },
         Err(err) => {
             logger::stderr(format!("Writing Changelog failed: {:?}", err));
@@ -97,7 +112,7 @@ fn main() {
         }
     }
 
-    match git::commit_files(&repository_path, &new_version) {
+    match git::commit_files(repository_path, &new_version) {
         Ok(_)    => { },
         Err(err) => {
             logger::stderr(format!("Committing `Cargo.toml` failed: {:?}", err));
@@ -106,7 +121,7 @@ fn main() {
     }
 
     logger::stdout("Creating annotated git tag");
-    let tag_message = match changelog::generate(&repository_path, &version.to_string(), &new_version) {
+    let tag_message = match changelog::generate(repository_path, &version.to_string(), &new_version) {
         Ok(msg) => msg,
         Err(err) => {
             logger::stderr(format!("Can't geneate changelog: {:?}", err));
@@ -115,7 +130,7 @@ fn main() {
     };
 
     let tag_name = format!("v{}", new_version);
-    match git::tag(&repository_path, &tag_name, &tag_message) {
+    match git::tag(repository_path, &tag_name, &tag_message) {
         Ok(_) => { },
         Err(err) => {
             logger::stderr(format!("Failed to create git tag: {:?}", err));


### PR DESCRIPTION
Not sure if we want to go that way but I do like `docopt` more than the alternatives (`argparse` as now or [`clap`](https://crates.io/crates/clap/)).

Also: handles the `--version` switch and already has a `--dry-run` flag.