### PR TITLE
Dry run mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,10 @@ $ cargo run
 
 This analyzes the current git repository and updates the project's `Cargo.toml`.
 
+## Run semantic-rs in CI environment
+
+Make sure to set the `CI=true` environment variable to disable dry-run mode.
+
 ## Contributing
 
 Bug reports and pull requests are welcome on [GitHub](https://github.com/semantic-rs/semantic-rs).

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use docopt::Docopt;
 use commit_analyzer::CommitType;
 use std::process;
 use semver::Version;
+use std::env;
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 const USAGE: &'static str = "
@@ -52,6 +53,10 @@ fn version_bump(version: &Version, bump: CommitType) -> Option<Version> {
     Some(version)
 }
 
+fn ci_env_set() -> bool {
+    env::var("CI").is_ok()
+}
+
 fn main() {
     let args: Args = Docopt::new(USAGE)
         .and_then(|d| d.decode())
@@ -62,7 +67,12 @@ fn main() {
         process::exit(0);
     }
 
-    let is_dry_run = !args.flag_write;
+    let is_dry_run = if ci_env_set() {
+        false
+    }
+    else {
+        !args.flag_write
+    };
 
     println!("semantic.rs 🚀");
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -30,13 +30,13 @@ Options:
   -h --help              Show this screen.
   --version              Show version.
   -p PATH, --path=PATH   Specifies the repository path. [default: .]
-  -n, --dry-run          Run without writing, committing, pushing or publishing anything.
+  -w, --write            Run with writing the changes afterwards.
 ";
 
 #[derive(Debug, RustcDecodable)]
 struct Args {
     flag_path: String,
-    flag_dry_run: bool,
+    flag_write: bool,
     flag_version: bool,
 }
 
@@ -61,6 +61,8 @@ fn main() {
         println!("semantic.rs 🚀 -- v{}", VERSION);
         process::exit(0);
     }
+
+    let is_dry_run = !args.flag_write;
 
     println!("semantic.rs 🚀");
 
@@ -89,7 +91,7 @@ fn main() {
     logger::stdout("Analyzing commits");
 
     let bump = git::version_bump_since_latest(repository_path);
-    if args.flag_dry_run {
+    if is_dry_run {
         logger::stdout(format!("Commits analyzed. Bump would be {:?}", bump));
     }
     else {
@@ -103,7 +105,7 @@ fn main() {
         }
     };
 
-    if args.flag_dry_run {
+    if is_dry_run {
         logger::stdout(format!("New version would be: {}", new_version));
         logger::stdout("Would write the following Changelog:");
         let changelog = match changelog::generate(repository_path, &version.to_string(), &new_version.to_string()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,7 +105,17 @@ fn main() {
 
     if args.flag_dry_run {
         logger::stdout(format!("New version would be: {}", new_version));
-        logger::stdout("Would write Changelog");
+        logger::stdout("Would write the following Changelog:");
+        let changelog = match changelog::generate(repository_path, &version.to_string(), &new_version.to_string()) {
+            Ok(log) => log,
+            Err(err) => {
+                logger::stderr(format!("Generating Changelog failed: {:?}", err));
+                process::exit(1);
+            }
+        };
+        logger::stdout("====================================");
+        logger::stdout(changelog);
+        logger::stdout("====================================");
         logger::stdout("Would create annotated git tag");
     }
     else {


### PR DESCRIPTION
PR for #39 

This PR enhances the `dry-run` mode by default. If the user runs semantic-rs like this:
```
% cargo run -- -p ../test-project
```
then they get shown what would happen if the changes where actually made. If they pass the `-w` or `--write` flag, the changes are performed.
If the `CI` environment variable is configured, then dry-run mode is disabled.