### PR TITLE
chore: get rid of the clog-fork and use the latest upstream version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2,7 +2,7 @@
 name = "semantic-rs"
 version = "0.1.0"
 dependencies = [
- "clog 0.9.0 (git+https://github.com/semantic-rs/clog-lib?branch=public-raw-parsing)",
+ "clog 0.9.0 (git+https://github.com/clog-tool/clog-lib.git)",
  "docopt 0.6.78 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2 0.3.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "git2-commit 0.1.0 (git+https://github.com/badboy/git2-commit-rs)",
@@ -38,7 +38,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 [[package]]
 name = "clog"
 version = "0.9.0"
-source = "git+https://github.com/semantic-rs/clog-lib?branch=public-raw-parsing#387d502460d353db520ed99a59c373d168c0e411"
+source = "git+https://github.com/clog-tool/clog-lib.git#34319d87229958e13740cdda647cc16817ab794c"
 dependencies = [
  "regex 0.1.48 (registry+https://github.com/rust-lang/crates.io-index)",
  "time 0.1.34 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,4 +14,4 @@ docopt = "0.6.78"
 rustc-serialize = "0.3.16"
 git2-commit = { git = "https://github.com/badboy/git2-commit-rs" }
 git2 = "0.3.4"
-clog = { git = "https://github.com/semantic-rs/clog-lib", branch = "public-raw-parsing" }
+clog = { git = "https://github.com/clog-tool/clog-lib.git" }


### PR DESCRIPTION
PR for #30 