### PR TITLE
chore(CI): Build leader should be stable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,9 +10,9 @@ addons:
 
 # run builds for both all the trains
 rust:
-  - nightly
-  - beta
   - stable
+  - beta
+  - nightly
 
 before_script:
   - |


### PR DESCRIPTION
We should do what we want others to do, so in favor of the upcoming "build leader will do the hard work" and "build leader is job 1" we make sure this is the stable build