### PR TITLE
Handle non standard commit msg format

### DIFF
--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -3,7 +3,7 @@ use clog::Clog;
 use clog::fmt::MarkdownWriter;
 use std::path::PathBuf;
 use std::io::prelude::*;
-use std::fs::{File,OpenOptions};
+use std::fs::OpenOptions;
 use std::io::Error;
 
 pub fn write(repository_path: &str, old_version: &str, new_version: &str) -> Result<(), String> {

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -18,14 +18,8 @@ fn prepend_to_file(filename: PathBuf, new_changelog: &str) -> Result<(), Error> 
     let mut f = try!(File::open(&filename));
     try!(f.read_to_string(&mut existing_file_content));
 
-    let mut file = match OpenOptions::new().create(true).write(true).open(filename) {
-        Ok(handle) => handle,
-        Err(err) => return Err(Error::from(err))
-    };
-    match file.write(format!("{}\n", new_changelog).as_bytes()) {
-        Ok(_) => {},
-        Err(err) => return Err(Error::from(err))
-    }
+    let mut file = try!(OpenOptions::new().create(true).write(true).open(filename));
+    try!(file.write(format!("{}\n", new_changelog).as_bytes()));
     match file.write(format!("{}\n", existing_file_content).as_bytes()) {
         Ok(_) => Ok(()),
         Err(err) => return Err(Error::from(err))
@@ -54,10 +48,7 @@ pub fn write_custom(repository_path: &str, new_version: &str, changelog_text: &s
         prepend_to_file(changelog_path, &changelog_text)
     }
     else {
-        let mut file = match OpenOptions::new().create(true).write(true).open(changelog_path) {
-            Ok(handle) => handle,
-            Err(err) => return Err(Error::from(err))
-        };
+        let mut file = try!(OpenOptions::new().create(true).write(true).open(changelog_path));
         match file.write(changelog_text.as_bytes()) {
             Ok(_) => Ok(()),
             Err(err) => return Err(Error::from(err))

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -27,8 +27,8 @@ pub fn write_custom(repository_path: &str, new_version: &str, changelog_text: &s
         Ok(f) => f,
         Err(err) => return Err(err)
     };
-    try!(file.write(format!("## {}", new_version).as_bytes()));
-    match file.write(changelog_text.as_bytes()) {
+    try!(file.write(format!("## v{}\n", new_version).as_bytes()));
+    match file.write(format!("{}\n", changelog_text).as_bytes()) {
         Ok(_) => Ok(()),
         Err(err) => Err(err)
     }

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -3,8 +3,28 @@ use clog::Clog;
 use clog::fmt::MarkdownWriter;
 use std::path::PathBuf;
 use std::io::prelude::*;
-use std::fs::OpenOptions;
+use std::fs::{self, File, OpenOptions};
 use std::io::Error;
+
+fn changelog_exists(path: &PathBuf) -> bool {
+    match fs::metadata(path) {
+        Ok(md) => md.is_file(),
+        Err(_) => return false
+    }
+}
+
+fn prepend_to_file(filename: PathBuf, new_changelog: &str) -> Result<(), String> {
+    let mut existing_file_content = String::new();
+    let mut f = File::open(&filename).expect("Failed to open Changelog for reading");
+    f.read_to_string(&mut existing_file_content).expect("Failed to read Changelog");
+
+    let mut file = OpenOptions::new().create(true).write(true).open(filename).expect("Failed to open Changelog for prepending new items");
+    file.write(format!("{}\n", new_changelog).as_bytes());
+    match file.write(format!("{}\n", existing_file_content).as_bytes()) {
+        Ok(_) => Ok(()),
+        Err(err) => Err(format!("Could not prepend text to changelog file: {:?}", err))
+    }
+}
 
 pub fn write(repository_path: &str, old_version: &str, new_version: &str) -> Result<(), String> {
     let mut clog = try!(Clog::with_dir(repository_path).map_err(|_| "Clog failed".to_owned()));
@@ -20,14 +40,20 @@ pub fn write(repository_path: &str, old_version: &str, new_version: &str) -> Res
     clog.write_changelog().map_err(|_| "Failed to write Changelog.md".to_owned())
 }
 
-pub fn write_custom(repository_path: &str, new_version: &str, changelog_text: &str) -> Result<(), Error> {
+pub fn write_custom(repository_path: &str, new_version: &str, changelog_text: &str) -> Result<(), String> {
     let mut changelog_path = PathBuf::from(repository_path);
     changelog_path.push("Changelog.md");
-    let mut file = try!(OpenOptions::new().create(true).write(true).open(changelog_path));
-    try!(file.write(format!("## v{}\n", new_version).as_bytes()));
-    match file.write(format!("{}\n", changelog_text).as_bytes()) {
-        Ok(_) => Ok(()),
-        Err(err) => Err(err)
+    let changelog_text = format!("## v{}\n{}", new_version, changelog_text);
+    if changelog_exists(&changelog_path) {
+        prepend_to_file(changelog_path, &changelog_text)
+    }
+    else {
+        let mut file = OpenOptions::new().create(true).write(true).open(changelog_path)
+            .expect("Failed to create new Changelog");
+        match file.write(changelog_text.as_bytes()) {
+            Ok(_) => Ok(()),
+            Err(err) => Err(format!("Could not prepend text to changelog file: {:?}", err))
+        }
     }
 }
 

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -23,10 +23,7 @@ pub fn write(repository_path: &str, old_version: &str, new_version: &str) -> Res
 pub fn write_custom(repository_path: &str, new_version: &str, changelog_text: &str) -> Result<(), Error> {
     let mut changelog_path = PathBuf::from(repository_path);
     changelog_path.push("Changelog.md");
-    let mut file = match OpenOptions::new().create(true).write(true).open(changelog_path) {
-        Ok(f) => f,
-        Err(err) => return Err(err)
-    };
+    let mut file = try!(OpenOptions::new().create(true).write(true).open(changelog_path));
     try!(file.write(format!("## v{}\n", new_version).as_bytes()));
     match file.write(format!("{}\n", changelog_text).as_bytes()) {
         Ok(_) => Ok(()),

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -18,7 +18,10 @@ fn prepend_to_file(filename: PathBuf, new_changelog: &str) -> Result<(), String>
     f.read_to_string(&mut existing_file_content).expect("Failed to read Changelog");
 
     let mut file = OpenOptions::new().create(true).write(true).open(filename).expect("Failed to open Changelog for prepending new items");
-    file.write(format!("{}\n", new_changelog).as_bytes());
+    match file.write(format!("{}\n", new_changelog).as_bytes()) {
+        Ok(_) => {},
+        Err(err) => return Err(format!("Could not prepend text to changelog file: {:?}", err))
+    }
     match file.write(format!("{}\n", existing_file_content).as_bytes()) {
         Ok(_) => Ok(()),
         Err(err) => Err(format!("Could not prepend text to changelog file: {:?}", err))

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -23,8 +23,8 @@ pub fn write(repository_path: &str, old_version: &str, new_version: &str) -> Res
 pub fn write_custom(repository_path: &str, new_version: &str, changelog_text: &str) -> Result<(), Error> {
     let mut changelog_path = PathBuf::from(repository_path);
     changelog_path.push("Changelog.md");
-    let mut file = match OpenOptions::new().write(true).open(changelog_path) {
-        Ok(mut f) => f,
+    let mut file = match OpenOptions::new().create(true).write(true).open(changelog_path) {
+        Ok(f) => f,
         Err(err) => return Err(err)
     };
     try!(file.write(format!("## {}", new_version).as_bytes()));

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -43,7 +43,7 @@ pub fn write(repository_path: &str, old_version: &str, new_version: &str) -> Res
 pub fn write_custom(repository_path: &str, new_version: &str, changelog_text: &str) -> Result<(), String> {
     let mut changelog_path = PathBuf::from(repository_path);
     changelog_path.push("Changelog.md");
-    let changelog_text = format!("## v{}\n{}", new_version, changelog_text);
+    let changelog_text = format!("## v{}\n{}\n", new_version, changelog_text);
     if changelog_exists(&changelog_path) {
         prepend_to_file(changelog_path, &changelog_text)
     }

--- a/src/changelog.rs
+++ b/src/changelog.rs
@@ -4,7 +4,6 @@ use clog::fmt::MarkdownWriter;
 use std::path::PathBuf;
 use std::io::prelude::*;
 use std::fs::{self, File, OpenOptions};
-use std::io::Error;
 
 fn changelog_exists(path: &PathBuf) -> bool {
     match fs::metadata(path) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -32,7 +32,6 @@ use std::{env,fs};
 use std::path::Path;
 use std::error::Error;
 use url::Url;
-use std::io::{self, Read};
 
 const VERSION: &'static str = env!("CARGO_PKG_VERSION");
 const USERAGENT: &'static str = concat!("semantic-rs/", env!("CARGO_PKG_VERSION"));


### PR DESCRIPTION
PR for #50 

When a project does not follow the conventional commit message guidelines we default to generate a standard changelog which is not generated from commits.

TODO:

- [x] Handle the case when there's already a `Changelog.md`. Prepend new items.
- ~~[ ] Pick changelog message based on version bump (Major, Minor, Fix, ...)~~ (Does not apply because after a first tag has been created we get an Unknown bump)
