### PR TITLE
feat: Check if remote is GitHub url

### DIFF
--- a/src/git.rs
+++ b/src/git.rs
@@ -137,7 +137,6 @@ pub fn push(config: &Config, tag_name: &str) -> Result<(), Error> {
 
     let branch    = &config.branch;
     let token     = config.gh_token.as_ref();
-    let email     = config.signature.email().unwrap();
 
     // We need to push both the branch we just committed as well as the tag we created.
     let branch_ref = format!("refs/heads/{}", branch);
@@ -154,8 +153,8 @@ pub fn push(config: &Config, tag_name: &str) -> Result<(), Error> {
         });
         opts.remote_callbacks(cbs);
     } else {
-        cbs.credentials(|_url, _username, _allowed| {
-            Cred::ssh_key_from_agent(&email)
+        cbs.credentials(|_url, username, _allowed| {
+            Cred::ssh_key_from_agent(&username.unwrap())
         });
         opts.remote_callbacks(cbs);
     }

--- a/src/git.rs
+++ b/src/git.rs
@@ -134,27 +134,31 @@ pub fn tag(config: &Config, tag_name: &str, tag_message: &str) -> Result<(), Err
 
 pub fn push(config: &Config, tag_name: &str) -> Result<(), Error> {
     let repo      = &config.repository;
-    let token     = config.gh_token.as_ref().unwrap();
 
-    let user      = config.user.as_ref().unwrap();
-    let repo_name = config.repository_name.as_ref().unwrap();
     let branch    = &config.branch;
+    let token     = config.gh_token.as_ref();
+    let email     = config.signature.email().unwrap();
 
     // We need to push both the branch we just committed as well as the tag we created.
     let branch_ref = format!("refs/heads/{}", branch);
     let tag_ref    = format!("refs/tags/{}", tag_name);
     let refs = [&branch_ref[..], &tag_ref[..]];
 
-    let url = format!("https://github.com/{}/{}.git", user, repo_name);
-
-    let mut remote = try!(repo.remote_anonymous(&url));
-
+    let mut remote = try!(repo.find_remote("origin"));
     let mut cbs = RemoteCallbacks::new();
-    cbs.credentials(|_url, _username, _allowed| {
-        Cred::userpass_plaintext(&token, "")
-    });
     let mut opts = PushOptions::new();
-    opts.remote_callbacks(cbs);
+
+    if config.gh_token.as_ref().is_some() {
+        cbs.credentials(|_url, _username, _allowed| {
+            Cred::userpass_plaintext(&token.unwrap(), "")
+        });
+        opts.remote_callbacks(cbs);
+    } else {
+        cbs.credentials(|_url, _username, _allowed| {
+            Cred::ssh_key_from_agent(&email)
+        });
+        opts.remote_callbacks(cbs);
+    }
 
     remote
         .push(&refs, Some(&mut opts))

--- a/src/github.rs
+++ b/src/github.rs
@@ -4,6 +4,24 @@ use error::Error;
 use super::USERAGENT;
 use config::Config;
 
+pub fn can_release(config: &Config) -> bool {
+    let repo = &config.repository;
+    match repo.find_remote("origin") {
+        Ok(remote) => {
+            let url = match remote.url() {
+                Some(u) => u,
+                None => return false
+            };
+            is_github_url(url)
+        },
+        Err(_) => false
+    }
+}
+
+pub fn is_github_url(url: &str) -> bool {
+    url.contains("github.com")
+}
+
 pub fn release(config: &Config, tag_name: &str, tag_message: &str) -> Result<(), Error> {
     let user      = &config.user.as_ref().unwrap()[..];
     let repo_name = &config.repository_name.as_ref().unwrap()[..];

--- a/src/main.rs
+++ b/src/main.rs
@@ -210,13 +210,15 @@ Global config");
                 config_builder.user(user);
                 config_builder.repository_name(repo_name);
 
-                let gh_token = env::var("GH_TOKEN")
-                    .unwrap_or_else(|err| print_exit!("GH_TOKEN not set: {:?}", err));
+                if github::is_github_url(&url) {
+                    let gh_token = env::var("GH_TOKEN")
+                        .unwrap_or_else(|err| print_exit!("GH_TOKEN not set: {:?}", err));
+                    config_builder.gh_token(gh_token);
+                }
 
                 let cargo_token = env::var("CARGO_TOKEN")
                     .unwrap_or_else(|err| print_exit!("CARGO_TOKEN not set: {:?}", err));
 
-                config_builder.gh_token(gh_token);
                 config_builder.cargo_token(cargo_token);
             },
             Err(err) => {
@@ -336,9 +338,13 @@ Global config");
             logger::stdout("Waiting a tiny bit, so GitHub can store the git tag");
             thread::sleep(Duration::from_secs(1));
 
-            logger::stdout("Creating GitHub release");
-            github::release(&config, &tag_name, &tag_message)
-                .unwrap_or_else(|err| print_exit!("Failed to create GitHub release: {:?}", err));
+            if github::can_release(&config) {
+                logger::stdout("Creating GitHub release");
+                github::release(&config, &tag_name, &tag_message)
+                    .unwrap_or_else(|err| print_exit!("Failed to create GitHub release: {:?}", err));
+            } else {
+                logger::stdout("Project not hosted on GitHub. Skipping release step");
+            }
 
             logger::stdout("Publishing crate on crates.io");
             if !cargo::publish(&config.repository_path, &config.cargo_token.as_ref().unwrap()) {

--- a/src/main.rs
+++ b/src/main.rs
@@ -335,7 +335,7 @@ Global config");
             git::push(&config, &tag_name)
                 .unwrap_or_else(|err| print_exit!("Failed to push git: {:?}", err));
 
-            logger::stdout("Waiting a tiny bit, so GitHub can store the git tag");
+            logger::stdout("Waiting a tiny bit, so remote source control can store the git tag");
             thread::sleep(Duration::from_secs(1));
 
             if github::can_release(&config) {


### PR DESCRIPTION
If it's not a GitHub url, we cannot create a release but we still can push and create tags.

TODO:

- [x] Fix hardcoded `https` url in push function in `git.rs`
- [x] Handle ssh auth in push function in `git.rs`

For both, take https://github.com/semantic-rs/semantic-rs/pull/86 into account