### PR TITLE
Refactor changelog and release code

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -57,6 +57,21 @@ Options:
   -b B, --branch=B       The branch on which releases should happen. [default: master].
 ";
 
+const COMMITTER_MESSAGE: &'static str = r"
+A release commit needs a committer name and email address.
+We tried fetching it from different locations, but couldn't find one.
+
+Committer information is taken from the following environment variables, if set:
+
+GIT_COMMITTER_NAME
+GIT_COMMITTER_EMAIL
+
+If none is set the normal git config is tried in the following order:
+
+Local repository config
+User config
+Global config";
+
 macro_rules! print_exit {
     ($fmt:expr) => {{
         logger::stderr($fmt);
@@ -243,20 +258,7 @@ fn main() {
             Ok(sig) => sig,
             Err(e) => {
                 logger::stderr(format!("Failed to get the committer's name and email address: {}", e.description()));
-                logger::stderr(r"
-A release commit needs a committer name and email address.
-We tried fetching it from different locations, but couldn't find one.
-
-Committer information is taken from the following environment variables, if set:
-
-GIT_COMMITTER_NAME
-GIT_COMMITTER_EMAIL
-
-If none is set the normal git config is tried in the following order:
-
-Local repository config
-User config
-Global config");
+                logger::stderr(COMMITTER_MESSAGE);
                 process::exit(1);
             }
         };

--- a/src/main.rs
+++ b/src/main.rs
@@ -147,6 +147,25 @@ fn release_on_cratesio(config: &config::Config) {
     }
 }
 
+fn generate_changelog(repository_path: &str, version: &Version, new_version: &String) -> String {
+    logger::stdout(format!("New version would be: {}", new_version));
+    logger::stdout("Would write the following Changelog:");
+    match changelog::generate(repository_path, &version.to_string(), new_version) {
+        Ok(log) => log,
+        Err(err) => {
+            logger::stderr(format!("Generating Changelog failed: {:?}", err));
+            process::exit(1)
+        }
+    }
+}
+
+fn print_changelog(changelog: &str) {
+    logger::stdout("====================================");
+    logger::stdout(changelog);
+    logger::stdout("====================================");
+    logger::stdout("Would create annotated git tag");
+}
+
 fn main() {
     env_logger::init().expect("Can't instantiate env logger");
 
@@ -304,19 +323,8 @@ Global config");
     };
 
     if !config.write_mode {
-        logger::stdout(format!("New version would be: {}", new_version));
-        logger::stdout("Would write the following Changelog:");
-        let changelog = match changelog::generate(repository_path, &version.to_string(), &new_version) {
-            Ok(log) => log,
-            Err(err) => {
-                logger::stderr(format!("Generating Changelog failed: {:?}", err));
-                process::exit(1);
-            }
-        };
-        logger::stdout("====================================");
-        logger::stdout(changelog);
-        logger::stdout("====================================");
-        logger::stdout("Would create annotated git tag");
+        let changelog = generate_changelog(repository_path, &version, &new_version);
+        print_changelog(&changelog);
     } else {
         logger::stdout(format!("New version: {}", new_version));
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -57,7 +57,7 @@ Options:
   -b B, --branch=B       The branch on which releases should happen. [default: master].
 ";
 
-const COMMITTER_MESSAGE: &'static str = r"
+const COMMITTER_ERROR_MESSAGE: &'static str = r"
 A release commit needs a committer name and email address.
 We tried fetching it from different locations, but couldn't find one.
 
@@ -258,7 +258,7 @@ fn main() {
             Ok(sig) => sig,
             Err(e) => {
                 logger::stderr(format!("Failed to get the committer's name and email address: {}", e.description()));
-                logger::stderr(COMMITTER_MESSAGE);
+                logger::stderr(COMMITTER_ERROR_MESSAGE);
                 process::exit(1);
             }
         };


### PR DESCRIPTION
This PR moves code out of the main function into smaller functions. This happens for generating and displaying the changelog and for the release to github/crates.io code.