### PR TITLE
fix(integration test): make script OS X compatible

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ Requirements:
   - Ubuntu: `libssl-dev`
   - Mac Homebrew: `openssl`
 - Rust 1.5 or later
+- OS X: coreutils:`brew install coreutils`
 
 Clone this project:
 

--- a/tests/integration/run-locally.sh
+++ b/tests/integration/run-locally.sh
@@ -2,6 +2,20 @@
 
 set -e
 
+if [[ `uname` == 'Darwin' ]]; then
+  hash greadlink 2>/dev/null || \
+  hash gcp 2>/dev/null || \
+  { echo >&2 "you're running OS X:
+  to make this script compatible coreutils  is required;
+  install with 'brew install coreutils'; Aborting."; exit 1; }
+  readlink() {
+    $(which greadlink) "$@"
+  }
+  cp() {
+    $(which gcp) "$@"
+  }
+fi
+
 cd $(dirname $(readlink -f $0))
 
 export WORKSPACE=$(readlink -f ../../..)/workspace


### PR DESCRIPTION
the bash script that launches the integration tests are
not OS X compatible

this PR makes them compatible by using coreutils counterparts
of the offending commands

Closes #103