### PR TITLE
chore: Use makefile to run unit and integration tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,15 @@
+TARGET = target/debug/semantic-rs
+SRC = $(wildcard src/*.rs)
+
+test: unit integrations
+
+build: $(TARGET)
+
+$(TARGET): $(SRC)
+	cargo build
+
+unit:
+	cargo test
+
+integrations: $(TARGET)
+	./tests/integration/run-locally.sh


### PR DESCRIPTION
With this (and `make` installed), running all tests is as easy as invoking `make`