### PR TITLE
fix: warnings by shellcheck && cd problem

### DIFF
--- a/tests/integration/run-locally.sh
+++ b/tests/integration/run-locally.sh
@@ -3,19 +3,22 @@
 set -e
 
 expandpath() {
-  CDPATH= cd -- "$1" && pwd -P
+  CDPATH=$(cd -- "$1" && pwd -P)
+  echo "$CDPATH"
 }
 
-SCRIPTPATH=$(expandpath "$(dirname -- $0)")
+SCRIPTPATH=$(expandpath "$(dirname -- "$0")")
 cd "$SCRIPTPATH"
 
-export WORKSPACE="$(expandpath ../../..)/workspace"
+export WORKSPACE
+WORKSPACE="$(expandpath ../../..)/workspace"
 
 git clone https://github.com/sstephenson/bats/ || true
-export PATH=$(pwd)/bats/bin:$(expandpath ../../target/debug):$PATH
+export PATH
+PATH=$(pwd)/bats/bin:$(expandpath ../../target/debug):$PATH
 
-rm -rf $WORKSPACE
-mkdir $WORKSPACE
-cp -ar fixtures/* $WORKSPACE
+rm -rf "$WORKSPACE"
+mkdir "$WORKSPACE"
+cp -aR fixtures/* "$WORKSPACE"
 
 bats integration.bats

--- a/tests/integration/run-locally.sh
+++ b/tests/integration/run-locally.sh
@@ -3,7 +3,7 @@
 set -e
 
 expandpath() {
-  CDPATH=cd -- "$1" && pwd -P
+  CDPATH="" cd -- "$1" && pwd -P
 }
 
 SCRIPTPATH=$(expandpath "$(dirname -- "$0")")

--- a/tests/integration/run-locally.sh
+++ b/tests/integration/run-locally.sh
@@ -18,6 +18,6 @@ PATH=$(pwd)/bats/bin:$(expandpath ../../target/debug):$PATH
 
 rm -rf "$WORKSPACE"
 mkdir "$WORKSPACE"
-cp -aR fixtures/* "$WORKSPACE"
+cp -a fixtures/* "$WORKSPACE"
 
 bats integration.bats

--- a/tests/integration/run-locally.sh
+++ b/tests/integration/run-locally.sh
@@ -3,8 +3,7 @@
 set -e
 
 expandpath() {
-  CDPATH=$(cd -- "$1" && pwd -P)
-  echo "$CDPATH"
+  CDPATH=cd -- "$1" && pwd -P
 }
 
 SCRIPTPATH=$(expandpath "$(dirname -- "$0")")


### PR DESCRIPTION
- fix following shellcheck warnings:
```
- tests/integration/run-locally.sh|6 col 9 warning| Remove space after = if trying to assign a value (for empty string, use var='' ... ).  [SC1007]
- tests/integration/run-locally.sh|9 col 39 warning| Double quote to prevent globbing and word splitting. [SC2086]
- tests/integration/run-locally.sh|12 col 8 warning| Declare and assign separately to avoid masking return values. [SC2155]
- tests/integration/run-locally.sh|15 col 8 warning| Declare and assign separately to avoid masking return values. [SC2155]
- tests/integration/run-locally.sh|17 col 8 warning| Double quote to prevent globbing and word splitting. [SC2086]
- tests/integration/run-locally.sh|18 col 7 warning| Double quote to prevent globbing and word splitting. [SC2086]
- tests/integration/run-locally.sh|19 col 19 warning| Double quote to prevent globbing and word splitting. [SC2086]
```

- fix `cd` flags problem problem mentioned in #103

Tested in mac, using `bash` and `sh` and `bash --posix`