### PR TITLE
Add build instructions for OS X 10.11 users

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,15 @@ Requirements:
   - Mac Homebrew: `openssl`
 - Rust 1.5 or later
 
+### For OS X > 10.10
+
+Note that since OS X 10.11 Apple doesn't ship development headers for OpenSSL anymore. In order to get it working, you need to export the following two variables in order to get the build working:
+
+```bash
+export OPENSSL_INCLUDE_DIR=$(brew --prefix openssl)/include
+export DEP_OPENSSL_INCLUDE=$(brew --prefix openssl)/include
+```
+
 Clone this project:
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -77,7 +77,6 @@ Requirements:
 Note that since OS X 10.11 Apple doesn't ship development headers for OpenSSL anymore. In order to get it working, you need to export the following two variables in order to get the build working:
 
 ```bash
-export OPENSSL_INCLUDE_DIR=$(brew --prefix openssl)/include
 export DEP_OPENSSL_INCLUDE=$(brew --prefix openssl)/include
 ```
 


### PR DESCRIPTION
Resolves #100 
On OS X 10.11 the build of semantic-rs fails because of missing OpenSSL headers. To prevent the build from failure, some environment variables need to be configured.