### PR TITLE
docs: Update build instructions for OS X > 10.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,11 +82,15 @@ Requirements:
 
 ### For OS X > 10.10
 
-Note that since OS X 10.11 Apple doesn't ship development headers for OpenSSL anymore. In order to get it working, you need to export the following two variables in order to get the build working:
+Note that since OS X 10.11 Apple doesn't ship development headers for OpenSSL anymore. In order to get it working, you need to run cargo with these variables configured:
 
 ```bash
-export DEP_OPENSSL_INCLUDE=$(brew --prefix openssl)/include
+OPENSSL_INCLUDE_DIR=`brew --prefix openssl`/include \
+OPENSSL_LIB_DIR=`brew --prefix openssl`/lib \
+cargo build
 ```
+
+### Build locally
 
 Clone this project:
 


### PR DESCRIPTION
Since Mac OS X 10.10 compiling against OpenSSL is a bit strange since as already mentioned in the README Apple doesn't ship Header files anymore. This updated build command resolves the build errors which occured before so semantic-rs can be compiled successfully on current OS X versions.