### PR TITLE
fix: we can only push if the gh_token is present

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,7 @@ pub struct Config {
 
 impl Config {
     pub fn can_push(&self) -> bool {
-        self.user.is_some() && self.repository_name.is_some()
+        self.user.is_some() && self.repository_name.is_some() && self.gh_token.is_some()
     }
 }
 


### PR DESCRIPTION
I tested to create a new release on a test project without the `GH_TOKEN` environment variable present. The result was that the process panicked because it tried to push without a `GH_TOKEN` being present.
The root cause for this was that the `can_push` guard only checked for `repository_name` and `username` but not for the `gh_token`. This PR adds the missing check for it.