### PR TITLE
Use hyper native tls

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -9,6 +9,7 @@ dependencies = [
  "git2 0.6.4 (registry+https://github.com/rust-lang/crates.io-index)",
  "hubcaps 0.3.1 (registry+https://github.com/rust-lang/crates.io-index)",
  "hyper 0.10.6 (registry+https://github.com/rust-lang/crates.io-index)",
+ "hyper-native-tls 0.2.2 (registry+https://github.com/rust-lang/crates.io-index)",
  "regex 0.1.80 (registry+https://github.com/rust-lang/crates.io-index)",
  "rustc-serialize 0.3.23 (registry+https://github.com/rust-lang/crates.io-index)",
  "semver 0.2.3 (registry+https://github.com/rust-lang/crates.io-index)",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ url = "1.2"
 clippy = {version = "<0.1.0", optional = true}
 travis-after-all = "2.0.0"
 env_logger = "0.3.0"
+hyper-native-tls = "0.2.2"
 
 [features]
 default = []

--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,7 @@ pub struct Config {
 
 impl Config {
     pub fn can_push(&self) -> bool {
-        self.user.is_some() && self.repository_name.is_some()
+        self.user.is_some() && self.repository_name.is_some() && self.gh_token.is_some()
     }
 }
 

--- a/src/github.rs
+++ b/src/github.rs
@@ -1,4 +1,6 @@
 use hyper::Client;
+use hyper::net::HttpsConnector;
+use hyper_native_tls::NativeTlsClient;
 use hubcaps::{Github, Credentials};
 use hubcaps::releases::ReleaseOptions;
 use error::Error;
@@ -29,7 +31,11 @@ pub fn release(config: &Config, tag_name: &str, tag_message: &str) -> Result<(),
     let branch    = &config.branch[..];
     let token     = config.gh_token.as_ref().unwrap();
 
-    let client = Client::new();
+    let client = Client::with_connector(
+        HttpsConnector::new(
+            NativeTlsClient::new().unwrap()
+        )
+    );
     let credentials = Credentials::Token(token.to_owned());
     let github = Github::new(USERAGENT, client, credentials);
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -26,6 +26,7 @@ extern crate hubcaps;
 extern crate url;
 extern crate travis_after_all;
 extern crate env_logger;
+extern crate hyper_native_tls;
 
 use docopt::Docopt;
 use commit_analyzer::CommitType;


### PR DESCRIPTION
Resolves #122 and based on #118 

This fixes the problem described in #122 that GitHub rejects pushes performed over http. This is caused by hyper which does not ship with its own tls implementation anymore. We fix this by including `hyper-native-tls` and configuring out GitHub client explicitly to use https.