### PR TITLE
Fix release behavior

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -22,7 +22,15 @@ pub struct Config {
 
 impl Config {
     pub fn can_push(&self) -> bool {
-        self.user.is_some() && self.repository_name.is_some() && self.gh_token.is_some()
+        self.user.is_some() && self.repository_name.is_some()
+    }
+
+    pub fn can_release_to_github(&self) -> bool {
+        self.can_push() && self.gh_token.is_some()
+    }
+
+    pub fn can_release_to_cratesio(&self) -> bool {
+        self.cargo_token.is_some()
     }
 }
 

--- a/src/git.rs
+++ b/src/git.rs
@@ -76,6 +76,15 @@ fn create_tag(config: &Config, tag_name: &str, message: &str) -> Result<(), git2
         .map(|_| ())
 }
 
+fn is_https_remote(maybe_remote: Option<&str>) -> bool {
+    if let Some(remote) = maybe_remote {
+        remote.to_string()
+              .starts_with("https://")
+    } else {
+        false
+    }
+}
+
 pub fn latest_tag(repo: &Repository) -> Option<Version> {
     let tags = match repo.tag_names(None) {
         Ok(tags) => tags,
@@ -147,7 +156,7 @@ pub fn push(config: &Config, tag_name: &str) -> Result<(), Error> {
     let mut cbs = RemoteCallbacks::new();
     let mut opts = PushOptions::new();
 
-    if config.gh_token.as_ref().is_some() {
+    if is_https_remote(remote.url()) {
         cbs.credentials(|_url, _username, _allowed| {
             Cred::userpass_plaintext(&token.unwrap(), "")
         });

--- a/src/git.rs
+++ b/src/git.rs
@@ -78,8 +78,7 @@ fn create_tag(config: &Config, tag_name: &str, message: &str) -> Result<(), git2
 
 fn is_https_remote(maybe_remote: Option<&str>) -> bool {
     if let Some(remote) = maybe_remote {
-        remote.to_string()
-              .starts_with("https://")
+        remote.starts_with("https://")
     } else {
         false
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -429,7 +429,13 @@ fn main() {
 
         if config.release_mode && config.can_push() {
             push_to_github(&config, &tag_name);
+        }
+
+        if config.release_mode && config.can_release_to_github() {
             release_on_github(&config, &tag_message, &tag_name);
+        }
+
+        if config.release_mode && config.can_release_to_cratesio() {
             release_on_cratesio(&config);
             println!("{} v{} is released. 🚀🚀🚀", config.repository_name.unwrap(), new_version);
         }


### PR DESCRIPTION
If we can push then we push tags and commits to GitHub either via HTTPS (and GH_TOKEN) or SSH. If the user has a GH_TOKEN configured, we also create a release on GitHub.

If the user has a CARGO_TOKEN configured, then we also release on crates.io. This is happening independently from GitHub releases and pushes. 

Superseeds #118 